### PR TITLE
Remove dapps section from .toml

### DIFF
--- a/node0.toml
+++ b/node0.toml
@@ -8,8 +8,6 @@ port = 8540
 apis = ["web3", "eth", "net", "personal", "parity", "parity_set", "traces", "rpc", "parity_accounts"]
 [ui]
 port = 8180
-[dapps]
-port = 8080
 [account]
 password = ["node.pwds"]
 [mining]

--- a/node1.toml
+++ b/node1.toml
@@ -8,8 +8,6 @@ port = 8541
 apis = ["web3", "eth", "net", "personal", "parity", "parity_set", "traces", "rpc", "parity_accounts"]
 [ui]
 port = 8181
-[dapps]
-port = 8081
 [account]
 password = ["node.pwds"]
 [mining]


### PR DESCRIPTION
I think it is not necessary any more.
- `Option '--dapps-port' is deprecated. Please use '--jsonrpc-port' instead.`