### PR TITLE
Fixes #9. Add password for user account of node0 to password file

### DIFF
--- a/node.pwds
+++ b/node.pwds
@@ -1,2 +1,3 @@
 node0
 node1
+user


### PR DESCRIPTION
Otherwise when you try to run node0 with `./target/release/parity --config node0.toml`, you'll get error `No valid password to unlock account 0x004e…f32e. Make sure valid password is present in files passed using `--password` or in the configuration file.`